### PR TITLE
Support more videos on carousel

### DIFF
--- a/_carousel_contents/content1.html
+++ b/_carousel_contents/content1.html
@@ -1,5 +1,0 @@
----
-title: PETA
-data: /img/carousel-image.jpg
-type: image
----

--- a/_carousel_contents/content2.html
+++ b/_carousel_contents/content2.html
@@ -1,5 +1,0 @@
----
-title: VAIO
-data: /img/carousel-image.jpg
-type: video
----

--- a/_config.yml
+++ b/_config.yml
@@ -14,8 +14,6 @@ markdown: kramdown
 
 #Collections
 collections:
-    carousel_contents:
-        output: true
     works:
         output: true
         permalink: /works/:name/

--- a/_data/carousel_contents.yml
+++ b/_data/carousel_contents.yml
@@ -1,0 +1,19 @@
+- slug: peta
+  content: /img/carousel-image.jpg
+  type: image
+
+- slug: mindanaw-tribal-school
+  content: http://www.youtube.com/embed/04C86cQ23Ug
+  type: youtube-video
+
+- slug: sony-vaio
+  content: http://www.youtube.com/embed/DfhwTkQ6oYw
+  type: youtube-video
+
+- slug: next-notebook-sony-vaio
+  content: http://www.youtube.com/embed/nk_nu0WfGQQ
+  type: youtube-video
+
+- slug: afs-philippines
+  content: http://www.youtube.com/embed/D0roiSM7P2c
+  type: youtube-video

--- a/_includes/front/carousel.html
+++ b/_includes/front/carousel.html
@@ -1,16 +1,17 @@
 <div id="home" class="carousel slide" data-interval="" data-stellar-ratio="1">
     <div class="carousel-inner">
-        {% for item in site.carousel_contents %}
+        {% for item in site.data.carousel_contents %}
             <div class="item {% if forloop.first %} active{% endif %}">
-                {% if item.type == 'image' %}
-                    <img src="{{ item.data | prepend: site.baseurl }}"/>
-
-                {% else %}
-                    <div class="video-container">
-                        <div id="vid">
+                {% case item.type %}
+                    {% when 'image' %}
+                        <img src="{{ item.content }}"/>
+                    {% when 'youtube-video' %}
+                        <div class="video-container">
+                            <iframe class="video-content" id="{{ item.slug }}"
+                                src="{{ item.content }}?enablejsapi=1&loop=1&controls=0&rel=0&info=0" 
+                                width="100%" height="100%"></iframe>
                         </div>
-                    </div>
-                {% endif %}
+                {% endcase %}
             </div>
         {% endfor %}
         <div class="gradient-overlay">

--- a/_sass/_front.scss
+++ b/_sass/_front.scss
@@ -37,7 +37,7 @@
     height: 0;
 }
 
-.video-container #vid {
+.video-container .video-content {
     position: absolute;
     top: 0;
     left: 0;

--- a/js/front.js
+++ b/js/front.js
@@ -49,38 +49,35 @@ $(function(){
   });
 });
 
-   var tag = document.createElement('script');
-      tag.src = "https://www.youtube.com/iframe_api";
-      var firstScriptTag = document.getElementsByTagName('script')[0];
-      firstScriptTag.parentNode.insertBefore(tag, firstScriptTag);
-      
-      var player;
-      function onYouTubeIframeAPIReady() {
-        player = new YT.Player('vid', {
-          width: '100%',
-          videoId: 'DfhwTkQ6oYw',
-          playerVars:{
-            origin: 'http://crux.ph',
-            controls: 0,
-            modestBranding: 0,
-            loop: 1,
-            rel: 0,
-            info: 0
-          }
-        });
-      }
+//Load YouTube iframe API
+var tag = document.createElement('script');
+tag.src = "https://www.youtube.com/iframe_api";
+var firstScriptTag = document.getElementsByTagName('script')[0];
+firstScriptTag.parentNode.insertBefore(tag, firstScriptTag);
+
+var ytVideos = [];
+function onYouTubeIframeAPIReady() {
+  //collect YouTube videos
+  $('.video-content').each(function(index, video){
+    ytVideos.push({
+      video_id: $(video).attr('id'),
+      player: new YT.Player(video)
+    });
+  });
+}
 
 $(document).ready(function(){
     function customPlayback(){
-        if ($('#vid').is(":in-viewport(200)")) {
-            player.playVideo();
-        } else if (player.getPlayerState()==1){
-            player.pauseVideo();
-        }
+        $.each(ytVideos, function(index, video){
+          if ($('#'+video.video_id).is(":in-viewport(200)")){
+            video.player.playVideo();
+          } else if (video.player.getPlayerState()==1){
+            video.player.pauseVideo();
+          }
+        });
     }
 
     $(window).scroll(customPlayback);
-
     $('.carousel').on('slid.bs.carousel', function(){
         customPlayback();
     });


### PR DESCRIPTION
This resolves #17 by moving the carousel contents to a data file rather than being in a collection. This appears more logical since the carousel contents only hold metadata for the content and do not handle the output of the contents themselves.

Also, support for multiple videos on the carousel was added. Pausing and playing when not in viewport as @japsendaydiego wishes.
